### PR TITLE
Fix traefik vhosts compose template

### DIFF
--- a/plugins/traefik-vhosts/templates/compose.yml.sigil
+++ b/plugins/traefik-vhosts/templates/compose.yml.sigil
@@ -33,8 +33,8 @@ services:
       - "traefik.http.routers.api.entrypoints={{ if $.TRAEFIK_LETSENCRYPT_EMAIL }}https{{ else }}http{{ end }}"
       {{ end }}
       
-      - "traefik.http.routers.api.middlewares=auth"
       {{ if $.TRAEFIK_BASIC_AUTH }}
+      - "traefik.http.routers.api.middlewares=auth"
       - "traefik.http.middlewares.auth.basicauth.users={{ $.TRAEFIK_BASIC_AUTH }}"
       {{ end }}
 


### PR DESCRIPTION
`auth` middleware label should only be added if `TRAEFIK_BASIC_AUTH` set